### PR TITLE
Add swift-package support

### DIFF
--- a/NYAlertViewController/NYAlertViewController.h
+++ b/NYAlertViewController/NYAlertViewController.h
@@ -40,6 +40,11 @@ typedef NS_ENUM(NSInteger, NYAlertViewControllerTransitionStyle) {
 @property (nonatomic) NSString *message;
 
 /**
+ The attributed message displayed under the alert view's title
+ */
+@property (nonatomic, strong) NSAttributedString *attributedMessage;
+
+/**
  A Boolean value that determines whether the status bar is visible when the alert view is presented
  */
 @property (nonatomic) BOOL showsStatusBar;

--- a/NYAlertViewController/NYAlertViewController.m
+++ b/NYAlertViewController/NYAlertViewController.m
@@ -539,6 +539,11 @@ static CGFloat const kDefaultDismissalAnimationDuration = 0.6f;
     self.view.messageTextView.text = message;
 }
 
+- (void)setAttributedMessage:(NSAttributedString *)attributedMessage {
+    _attributedMessage = attributedMessage;
+    self.view.messageTextView.attributedText = attributedMessage;
+}
+
 - (UIFont *)titleFont {
     return self.view.titleLabel.font;
 }

--- a/NYAlertViewController/include/NYAlertViewController-UmbrellaHeader.h
+++ b/NYAlertViewController/include/NYAlertViewController-UmbrellaHeader.h
@@ -1,0 +1,8 @@
+//
+//  NYAlertViewController-UmbrellaHeader.h
+//  
+//
+//  Created by Ettore Gallina on 12/04/23.
+//
+
+#import "../NYAlertViewController.h"

--- a/Package.swift
+++ b/Package.swift
@@ -24,8 +24,7 @@ let package = Package(
         .target(
             name: "NYAlertViewController",
             dependencies: [],
-            path: "NYAlertViewController",
-            publicHeadersPath: "../NYAlertViewController"
+            path: "NYAlertViewController"
         )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,31 @@
+// swift-tools-version: 5.8
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "NYAlertViewController",
+    platforms: [
+        .iOS(.v11)
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "NYAlertViewController",
+            targets: ["NYAlertViewController"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "NYAlertViewController",
+            dependencies: [],
+            path: "NYAlertViewController",
+            publicHeadersPath: "../NYAlertViewController"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ Add the files to your project manually by dragging the NYAlertViewController dir
 #### CocoaPods
 Add `pod 'NYAlertViewController'` to your Podfile, and run `pod install`.
 
+#### Swift Package Manager
+Open your project in Xcode
+
+1. Click "File" -> "Add Packages..."
+2. Paste the following URL: https://github.com/gallinaettore/NYAlertViewController
+
+You can specify the dependency in `Package.swift` by adding this:
+```swift
+.package(url: "https://github.com/gallinaettore/NYAlertViewController.git", .upToNextMajor(from: "1.4.0"))
+```
+
 ### Usage Examples
 An Objective-C example project demonstrating customization options is included in the NYAlertViewControllerDemo directory.
 


### PR DESCRIPTION
I've added support for the new swift-package so you can install the library via both CocoaPods and SPM.

In a previous commit I also added the possibility to set an attributed message.

When you pull, remember to update the link in the README.md file https://github.com/gallinaettore/NYAlertViewController with https://github.com/nealyoung/NYAlertViewController